### PR TITLE
Update rtl433-to-mqtt.h - Fix compile on newer ESPHome versions

### DIFF
--- a/rtl433-to-mqtt.h
+++ b/rtl433-to-mqtt.h
@@ -8,7 +8,7 @@
 
 #include "rtl_433_ESP.h"
 
-class Rtl433ToMqtt : public Component, public CustomMQTTDevice {
+class Rtl433ToMqtt : public esphome::Component, public esphome::mqtt::CustomMQTTDevice {
  public:
   Rtl433ToMqtt(const char* source) : source_(source) {
     instance_ = this;


### PR DESCRIPTION
Without this change, this fails to compile on ESPHome 2024.04.02.