### PR TITLE
Fix compilation with ESPHome 2024.6.0 and later

### DIFF
--- a/rtl433-to-mqtt.h
+++ b/rtl433-to-mqtt.h
@@ -52,6 +52,7 @@ void Rtl433ToMqtt::process(char* msg) {
   ESP_LOGD("custom", "Received msg: %s", msg);
   parse_json(msg, [this](JsonObject doc) {
     process_json(doc);
+    return true;
   });
 }
 


### PR DESCRIPTION
https://github.com/esphome/esphome/pull/6884 - This breaking change's description is misleading.  It states "allow" a boolean result, but in fact *requires* a boolean result